### PR TITLE
Dev

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeRecords"
 uuid = "b543fe20-4c68-4b5f-af79-4641a0d39826"
 authors = ["Ruben Gonzalez <ruben.carbonbased@gmail.com> and contributors"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeRecords.jl
+++ b/src/TimeRecords.jl
@@ -30,6 +30,5 @@ module TimeRecords
         findouter,
         findbounds,
         clampedbounds,
-        extendedbounds,
         keeplatest!
 end

--- a/src/_TimeSeries.jl
+++ b/src/_TimeSeries.jl
@@ -55,13 +55,11 @@ function Base.keepat!(ts::AbstractTimeSeries, inds)
     return ts
 end
 
-Base.length(ts::AbstractTimeSeries)         = length(records(ts))
-Base.size(ts::AbstractTimeSeries)           = (length(records(ts)),)
-Base.firstindex(ts::AbstractTimeSeries)     = firstindex(records(ts))
-Base.lastindex(ts::AbstractTimeSeries)      = lastindex(records(ts))
-Base.sort!(ts::AbstractTimeSeries)          = sort!(records(ts))
-
-
+Base.length(ts::AbstractTimeSeries)      = length(records(ts))
+Base.size(ts::AbstractTimeSeries)        = (length(records(ts)),)
+Base.firstindex(ts::AbstractTimeSeries)  = firstindex(records(ts))
+Base.lastindex(ts::AbstractTimeSeries)   = lastindex(records(ts))
+Base.sort!(ts::AbstractTimeSeries)       = sort!(records(ts))
 
 """
 push!(ts::TimeSeries, tr::TimeRecord)

--- a/src/interpolate.jl
+++ b/src/interpolate.jl
@@ -97,7 +97,7 @@ Will return TimeRecord{t, Missing} if t is not within the range of the timeserie
 """
 function strictinterp(f_extrap::Function, ts::AbstractTimeSeries, t::Real, indhint=nothing)
     (lb, ub) = findbounds(ts, t, indhint)
-    if isnothing(lb) | isnothing(ub)
+    if !(checkbounds(Bool, ts, lb) & checkbounds(Bool, ts, ub))
         return TimeRecord(t, missing)
     else
         return f_extrap(ts[lb], ts[ub], t)


### PR DESCRIPTION
Bumped version, modified findbounds to behave like extendedbounds (will provide bounds that are potentially out of range) and removed extendedbounds (because its behaviour is now like findbounds). This simplifies the API and removes a number of branches inside many algorithms (due to previous dispatch on Nothing).