### PR TITLE
Fixed type-instability on "average"

### DIFF
--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -115,7 +115,7 @@ Performance recommendations:
 function average(ts::AbstractTimeSeries{T}, Δt::TimeInterval; indhint=nothing, order=0) where T
     dt = diff(Δt)
     if iszero(dt) #Interval is zero, simply interpolate for the average (limit when dt=>0)
-        return interpolate(ts, Δt[begin], indhint=indhint, order=order)
+        return value(interpolate(ts, Δt[begin], indhint=indhint, order=order))
     else
         return integrate(ts, Δt, indhint=indhint, order=order)/dt
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,11 @@ using Dates
     @test values(accumulate(ts, order=0)) ≈ [1, 3, 6, 10]
     @test values(accumulate(ts, order=1)) ≈ [1.5, 4.0, 7.5, 12.0]
 
+    @test average(ts, TimeInterval(1,2), order=0) ≈ 1
+    @test average(ts, TimeInterval(1,2), order=1) ≈ 1.5
+    @test average(ts, TimeInterval(2,2), order=0) ≈ 2
+    @test average(ts, TimeInterval(2,2), order=1) ≈ 2
+
     #Test merging timeseries
     ts2 = TimeSeries([1.5, 2.6], [1.5, 2.6])
     @test values(merge(SVector, ts, ts2, order=1)) ≈ [ 


### PR DESCRIPTION
where it sometimes returned a TimeRecord instead of a value